### PR TITLE
Add tox and egg artifacts to .gitignore

### DIFF
--- a/examples/pyproj/.gitignore
+++ b/examples/pyproj/.gitignore
@@ -1,5 +1,8 @@
 *.py[cod]
 __pycache__
+.tox
+*.egg-info
+.cache
 
 # Sphinx
 # docs/_build


### PR DESCRIPTION
It's very common to have `tox` included as part of python package setups nowadays. It's probably safe to assume that this should be included as part of the standard setup :)